### PR TITLE
add durable workflow engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,41 @@ async fn store(_req: Request) -> Response {
 - **Modern frontend** — First-class Inertia.js + React with automatic TypeScript types
 - **Rust performance** — All the safety and speed, none of the ceremony
 
+## Durable Workflows
+
+Kit includes a Postgres-backed workflow engine with durable steps and retries.
+
+```rust
+use kit::{workflow, workflow_step, start_workflow, FrameworkError};
+
+#[workflow_step]
+async fn fetch_user(user_id: i64) -> Result<String, FrameworkError> {
+    Ok(format!("user:{}", user_id))
+}
+
+#[workflow_step]
+async fn send_welcome_email(user: String) -> Result<(), FrameworkError> {
+    println!("Sending email to {}", user);
+    Ok(())
+}
+
+#[workflow]
+async fn welcome_flow(user_id: i64) -> Result<(), FrameworkError> {
+    let user = fetch_user(user_id).await?;
+    send_welcome_email(user).await?;
+    Ok(())
+}
+
+// Enqueue
+// let handle = start_workflow!(welcome_flow, 123).await?;
+```
+
+Run the worker in production:
+
+```bash
+kit workflow:work
+```
+
 ## End-to-End Type Safety
 
 Kit provides automatic TypeScript type generation from your Rust structs. Define your props once in Rust, and use them with full type safety in React.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Welcome to the Kit framework documentation. Kit is a modern, Laravel-inspired we
 - [Service Container](./service-container.md) *(coming soon)*
 - [Configuration](./configuration.md) *(coming soon)*
 - [Testing](./testing.md) *(coming soon)*
+- [Workflows](./workflows.md)
 
 ### CLI Reference
 - [CLI Commands](./cli.md) *(coming soon)*

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,79 @@
+# Workflows
+
+Kit includes a durable, Postgres‑backed workflow engine with step persistence and automatic retries. Workflows resume from the last successful step on retry.
+
+## Install Migrations
+
+Run the install command once per app, then migrate:
+
+```bash
+kit workflow:install
+kit migrate
+```
+
+This creates two tables:
+
+- `workflows`
+- `workflow_steps`
+
+## Define Steps and Workflows
+
+Use attribute macros to define steps and workflows. Steps are cached automatically when invoked inside a workflow.
+
+```rust
+use kit::{workflow, workflow_step, start_workflow, FrameworkError};
+
+#[workflow_step]
+async fn fetch_user(user_id: i64) -> Result<String, FrameworkError> {
+    // Any I/O or queries here
+    Ok(format!("user:{}", user_id))
+}
+
+#[workflow_step]
+async fn send_welcome_email(user: String) -> Result<(), FrameworkError> {
+    println!("Sending email to {}", user);
+    Ok(())
+}
+
+#[workflow]
+async fn welcome_flow(user_id: i64) -> Result<(), FrameworkError> {
+    let user = fetch_user(user_id).await?;
+    send_welcome_email(user).await?;
+    Ok(())
+}
+```
+
+## Enqueue a Workflow
+
+Use `start_workflow!` to enqueue. Arguments are serialized as JSON and stored in Postgres.
+
+```rust
+let handle = start_workflow!(welcome_flow, 123).await?;
+let status = handle.wait().await?;
+```
+
+## Run the Worker
+
+Run workers as a separate process in production (similar to scheduled jobs):
+
+```bash
+kit workflow:work
+```
+
+## Configuration
+
+Set these environment variables as needed:
+
+- `WORKFLOW_POLL_INTERVAL_MS` (default: `1000`)
+- `WORKFLOW_CONCURRENCY` (default: `4`)
+- `WORKFLOW_LOCK_TIMEOUT_SECS` (default: `30`)
+- `WORKFLOW_MAX_ATTEMPTS` (default: `3`)
+- `WORKFLOW_RETRY_BACKOFF_SECS` (default: `5`)
+
+Retry backoff is linear: `attempt * WORKFLOW_RETRY_BACKOFF_SECS`.
+
+## Notes
+
+- The worker requires **Postgres** (uses `FOR UPDATE SKIP LOCKED`).
+- Steps should be deterministic and side‑effect safe since retries resume at the last failed step.
+- Outputs and inputs are stored as JSON TEXT, so return types must be serde‑serializable.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -76,4 +76,5 @@ Retry backoff is linear: `attempt * WORKFLOW_RETRY_BACKOFF_SECS`.
 
 - The worker requires **Postgres** (uses `FOR UPDATE SKIP LOCKED`).
 - Steps should be deterministic and side‑effect safe since retries resume at the last failed step.
+- Step caching is keyed by **step name + index**. If a retry executes a different step at the same index, the worker returns an error. Prefer stable step order and put branching logic inside a step when possible.
 - Outputs and inputs are stored as JSON TEXT, so return types must be serde‑serializable.

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -12,9 +12,12 @@ pub mod inertia;
 pub mod middleware;
 pub mod routing;
 pub mod schedule;
+pub mod workflow;
 pub mod server;
 pub mod session;
 pub mod testing;
+
+extern crate self as kit;
 
 pub use app::Application;
 pub use auth::{Auth, Authenticatable, AuthMiddleware, GuestMiddleware, UserProvider};
@@ -47,6 +50,10 @@ pub use routing::{
     IntoGroupItem, RouteBuilder, RouteDefBuilder, Router,
 };
 pub use schedule::{CronExpression, DayOfWeek, Schedule, Task, TaskBuilder, TaskEntry, TaskResult};
+pub use workflow::{
+    start_named, StepStatus, WorkflowConfig, WorkflowContext, WorkflowHandle, WorkflowStatus,
+    WorkflowWorker,
+};
 pub use server::Server;
 
 // Re-export async_trait for middleware implementations
@@ -75,6 +82,8 @@ pub use kit_macros::injectable;
 pub use kit_macros::redirect;
 pub use kit_macros::request;
 pub use kit_macros::service;
+pub use kit_macros::workflow;
+pub use kit_macros::workflow_step;
 pub use kit_macros::FormRequest as FormRequestDerive;
 pub use kit_macros::InertiaProps;
 pub use kit_macros::kit_test;

--- a/framework/src/workflow/config.rs
+++ b/framework/src/workflow/config.rs
@@ -1,0 +1,45 @@
+//! Workflow configuration
+
+use crate::config::env;
+
+/// Workflow configuration
+///
+/// # Environment Variables
+///
+/// - `WORKFLOW_POLL_INTERVAL_MS` - Worker poll interval in milliseconds (default: 1000)
+/// - `WORKFLOW_CONCURRENCY` - Number of workflows to process concurrently (default: 4)
+/// - `WORKFLOW_LOCK_TIMEOUT_SECS` - Lease duration in seconds (default: 30)
+/// - `WORKFLOW_MAX_ATTEMPTS` - Max workflow attempts (default: 3)
+/// - `WORKFLOW_RETRY_BACKOFF_SECS` - Linear backoff seconds (default: 5)
+#[derive(Debug, Clone)]
+pub struct WorkflowConfig {
+    /// Worker poll interval in milliseconds
+    pub poll_interval_ms: u64,
+    /// Max concurrent workflows processed by a worker
+    pub concurrency: usize,
+    /// Lease duration in seconds
+    pub lock_timeout_secs: u64,
+    /// Max attempts per workflow
+    pub max_attempts: i32,
+    /// Linear backoff seconds per attempt
+    pub retry_backoff_secs: i64,
+}
+
+impl WorkflowConfig {
+    /// Build config from environment variables
+    pub fn from_env() -> Self {
+        Self {
+            poll_interval_ms: env("WORKFLOW_POLL_INTERVAL_MS", 1000u64),
+            concurrency: env("WORKFLOW_CONCURRENCY", 4usize),
+            lock_timeout_secs: env("WORKFLOW_LOCK_TIMEOUT_SECS", 30u64),
+            max_attempts: env("WORKFLOW_MAX_ATTEMPTS", 3i32),
+            retry_backoff_secs: env("WORKFLOW_RETRY_BACKOFF_SECS", 5i64),
+        }
+    }
+}
+
+impl Default for WorkflowConfig {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}

--- a/framework/src/workflow/context.rs
+++ b/framework/src/workflow/context.rs
@@ -1,0 +1,144 @@
+//! Workflow execution context
+
+use crate::error::FrameworkError;
+use crate::workflow::store;
+use crate::workflow::types::StepStatus;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::future::Future;
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct WorkflowContext {
+    inner: Arc<WorkflowContextInner>,
+}
+
+struct WorkflowContextInner {
+    workflow_id: i64,
+    lock_timeout: Duration,
+    step_index: AtomicI32,
+}
+
+tokio::task_local! {
+    static CONTEXT: WorkflowContext;
+}
+
+impl WorkflowContext {
+    pub(crate) fn new(workflow_id: i64, lock_timeout: Duration) -> Self {
+        Self {
+            inner: Arc::new(WorkflowContextInner {
+                workflow_id,
+                lock_timeout,
+                step_index: AtomicI32::new(0),
+            }),
+        }
+    }
+
+    /// Run a future within this workflow context
+    pub async fn enter<T, Fut>(self, fut: Fut) -> T
+    where
+        Fut: Future<Output = T>,
+    {
+        CONTEXT.scope(self, fut).await
+    }
+
+    /// Get the current workflow context if set
+    pub fn current() -> Option<Self> {
+        CONTEXT.try_with(|ctx| ctx.clone()).ok()
+    }
+
+    /// Check if workflow context is active
+    pub fn is_active() -> bool {
+        CONTEXT.try_with(|_| ()).is_ok()
+    }
+
+    /// Run a workflow step with pre-serialized input JSON
+    pub async fn run_step_with_input<F, Fut, T>(
+        &self,
+        step_name: &str,
+        input_json: String,
+        f: F,
+    ) -> Result<T, FrameworkError>
+    where
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, FrameworkError>> + Send + 'static,
+        T: Serialize + DeserializeOwned + Send + 'static,
+    {
+        let workflow_id = self.inner.workflow_id;
+        let step_index = self.inner.step_index.fetch_add(1, Ordering::SeqCst);
+
+        if let Some(existing) = store::load_step(workflow_id, step_index).await? {
+            if let Some(status) = StepStatus::from_str(&existing.status) {
+                if status == StepStatus::Succeeded {
+                    let output_json = existing.output.ok_or_else(|| {
+                        FrameworkError::internal("Step output missing for succeeded step")
+                    })?;
+                    let value = serde_json::from_str(&output_json).map_err(|e| {
+                        FrameworkError::internal(format!(
+                            "Workflow step output deserialize error: {}",
+                            e
+                        ))
+                    })?;
+                    store::refresh_lock(workflow_id, self.inner.lock_timeout).await?;
+                    return Ok(value);
+                }
+            }
+
+            store::update_step_running(existing, &input_json).await?;
+        } else {
+            store::insert_step_running(workflow_id, step_index, step_name, &input_json).await?;
+        }
+
+        store::refresh_lock(workflow_id, self.inner.lock_timeout).await?;
+
+        let result = f().await;
+
+        match result {
+            Ok(value) => {
+                let output_json = serde_json::to_string(&value).map_err(|e| {
+                    FrameworkError::internal(format!(
+                        "Workflow step output serialize error: {}",
+                        e
+                    ))
+                })?;
+                if let Some(step) = store::load_step(workflow_id, step_index).await? {
+                    store::mark_step_succeeded(step.id, &output_json).await?;
+                }
+                store::refresh_lock(workflow_id, self.inner.lock_timeout).await?;
+                Ok(value)
+            }
+            Err(err) => {
+                if let Some(step) = store::load_step(workflow_id, step_index).await? {
+                    store::mark_step_failed(step.id, &err.to_string()).await?;
+                }
+                store::refresh_lock(workflow_id, self.inner.lock_timeout).await?;
+                Err(err)
+            }
+        }
+    }
+
+    /// Run a workflow step with serializable arguments
+    pub async fn run_step<Args, F, Fut, T>(
+        &self,
+        step_name: &str,
+        args: &Args,
+        f: F,
+    ) -> Result<T, FrameworkError>
+    where
+        Args: Serialize,
+        F: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<T, FrameworkError>> + Send + 'static,
+        T: Serialize + DeserializeOwned + Send + 'static,
+    {
+        let input_json = serde_json::to_string(args).map_err(|e| {
+            FrameworkError::internal(format!(
+                "Workflow step input serialize error: {}",
+                e
+            ))
+        })?;
+
+        self.run_step_with_input(step_name, input_json, f).await
+    }
+}

--- a/framework/src/workflow/entities.rs
+++ b/framework/src/workflow/entities.rs
@@ -1,0 +1,65 @@
+//! SeaORM entities for workflows
+
+pub mod workflows {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "workflows")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i64,
+        pub name: String,
+        pub status: String,
+        #[sea_orm(column_type = "Text")]
+        pub input: String,
+        #[sea_orm(column_type = "Text", nullable)]
+        pub output: Option<String>,
+        #[sea_orm(column_type = "Text", nullable)]
+        pub error: Option<String>,
+        pub attempts: i32,
+        pub max_attempts: i32,
+        pub next_run_at: Option<chrono::NaiveDateTime>,
+        pub locked_until: Option<chrono::NaiveDateTime>,
+        pub worker_id: Option<String>,
+        pub created_at: chrono::NaiveDateTime,
+        pub updated_at: chrono::NaiveDateTime,
+        pub started_at: Option<chrono::NaiveDateTime>,
+        pub completed_at: Option<chrono::NaiveDateTime>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod workflow_steps {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "workflow_steps")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i64,
+        pub workflow_id: i64,
+        pub step_index: i32,
+        pub step_name: String,
+        pub status: String,
+        #[sea_orm(column_type = "Text")]
+        pub input: String,
+        #[sea_orm(column_type = "Text", nullable)]
+        pub output: Option<String>,
+        #[sea_orm(column_type = "Text", nullable)]
+        pub error: Option<String>,
+        pub attempts: i32,
+        pub created_at: chrono::NaiveDateTime,
+        pub updated_at: chrono::NaiveDateTime,
+        pub started_at: Option<chrono::NaiveDateTime>,
+        pub completed_at: Option<chrono::NaiveDateTime>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}

--- a/framework/src/workflow/mod.rs
+++ b/framework/src/workflow/mod.rs
@@ -1,0 +1,544 @@
+//! Durable workflow engine
+//!
+//! Provides a Postgres-backed durable workflow system with step persistence
+//! and automatic retries. Inspired by Laravel queues and DBOS.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use kit::{workflow, workflow_step, start_workflow, FrameworkError};
+//!
+//! #[workflow_step]
+//! async fn fetch_user(user_id: i64) -> Result<String, FrameworkError> {
+//!     Ok(format!("user:{}", user_id))
+//! }
+//!
+//! #[workflow_step]
+//! async fn send_email(user: String) -> Result<(), FrameworkError> {
+//!     println!("Sending email to {}", user);
+//!     Ok(())
+//! }
+//!
+//! #[workflow]
+//! async fn welcome_flow(user_id: i64) -> Result<(), FrameworkError> {
+//!     let user = fetch_user(user_id).await?;
+//!     send_email(user).await?;
+//!     Ok(())
+//! }
+//!
+//! // Enqueue a workflow
+//! // let handle = start_workflow!(welcome_flow, 123).await?;
+//! // handle.wait().await?;
+//!
+//! // Run worker (separate process):
+//! // kit workflow:work
+//! ```
+
+pub mod config;
+pub mod context;
+pub mod entities;
+#[doc(hidden)]
+pub mod registry;
+pub mod store;
+pub mod types;
+
+pub use config::WorkflowConfig;
+pub use context::WorkflowContext;
+pub use types::{StepStatus, WorkflowHandle, WorkflowStatus};
+
+use crate::config::Config;
+use crate::error::FrameworkError;
+use crate::workflow::types::ClaimedWorkflow;
+use chrono::{Duration as ChronoDuration, Utc};
+use rand::Rng;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+/// Start a workflow by name with serialized input JSON
+pub async fn start_named(name: &str, input: &str) -> Result<WorkflowHandle, FrameworkError> {
+    if registry::find(name).is_none() {
+        return Err(FrameworkError::internal(format!(
+            "Workflow '{}' is not registered",
+            name
+        )));
+    }
+
+    let config = Config::get::<WorkflowConfig>().unwrap_or_default();
+    store::insert_workflow(name, input, config.max_attempts).await
+}
+
+/// Normalize a workflow name to module_path::fn_name form
+pub fn normalize_workflow_name(name: &str) -> String {
+    let trimmed = name.replace(' ', "");
+    if trimmed.contains("::") {
+        trimmed
+    } else {
+        format!("{}::{}", module_path!(), trimmed)
+    }
+}
+
+/// Workflow worker daemon
+pub struct WorkflowWorker {
+    config: Arc<WorkflowConfig>,
+    worker_id: String,
+}
+
+impl WorkflowWorker {
+    /// Create a worker with config from environment
+    pub fn new() -> Self {
+        let config = Config::get::<WorkflowConfig>().unwrap_or_default();
+        Self::with_config(config)
+    }
+
+    /// Create a worker with a custom config
+    pub fn with_config(config: WorkflowConfig) -> Self {
+        let random: u64 = rand::thread_rng().gen();
+        let worker_id = format!("{}-{}", std::process::id(), random);
+        Self {
+            config: Arc::new(config),
+            worker_id,
+        }
+    }
+
+    /// Run the worker loop indefinitely
+    pub async fn work_loop() -> Result<(), FrameworkError> {
+        Self::new().run().await
+    }
+
+    async fn run(self) -> Result<(), FrameworkError> {
+        let poll = Duration::from_millis(self.config.poll_interval_ms);
+        let semaphore = Arc::new(Semaphore::new(self.config.concurrency));
+
+        loop {
+            let permit = semaphore.clone().acquire_owned().await.unwrap();
+            let claim = store::claim_next_workflow(&self.worker_id, &self.config).await?;
+
+            match claim {
+                Some(claimed) => {
+                    let config = self.config.clone();
+                    let worker_id = self.worker_id.clone();
+                    tokio::spawn(async move {
+                        if let Err(err) = process_claimed_workflow(claimed, config, &worker_id).await {
+                            eprintln!("Workflow execution error: {}", err);
+                        }
+                        drop(permit);
+                    });
+                }
+                None => {
+                    drop(permit);
+                    tokio::time::sleep(poll).await;
+                }
+            }
+        }
+    }
+}
+
+async fn process_claimed_workflow(
+    claimed: ClaimedWorkflow,
+    config: Arc<WorkflowConfig>,
+    _worker_id: &str,
+) -> Result<(), FrameworkError> {
+    let entry = match registry::find(&claimed.name) {
+        Some(entry) => entry,
+        None => {
+            store::mark_failed(claimed.id, "Workflow not registered").await?;
+            return Ok(());
+        }
+    };
+
+    let ctx = WorkflowContext::new(
+        claimed.id,
+        Duration::from_secs(config.lock_timeout_secs),
+    );
+
+    let result = ctx
+        .enter(async { (entry.run)(&claimed.input).await })
+        .await;
+
+    match result {
+        Ok(output) => {
+            store::mark_succeeded(claimed.id, &output).await?;
+        }
+        Err(err) => {
+            if claimed.attempts < claimed.max_attempts {
+                let backoff = config.retry_backoff_secs * claimed.attempts as i64;
+                let next_run_at = Utc::now().naive_utc() + ChronoDuration::seconds(backoff);
+                store::requeue(claimed.id, &err.to_string(), next_run_at).await?;
+            } else {
+                store::mark_failed(claimed.id, &err.to_string()).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Enqueue a workflow by function name with serialized args
+///
+/// Example:
+/// ```rust,ignore
+/// let handle = start_workflow!(my_workflow, 42, "hello").await?;
+/// ```
+#[macro_export]
+macro_rules! start_workflow {
+    ($workflow:path $(, $arg:expr)* $(,)?) => {{
+        let __name = stringify!($workflow);
+        let __name = if __name.contains("::") {
+            __name.to_string()
+        } else {
+            format!("{}::{}", module_path!(), __name)
+        };
+        let __name = __name.replace(' ', "");
+        let __input = ::kit::serde_json::to_string(&( $($arg,)* ))
+            .map_err(|e| ::kit::FrameworkError::internal(format!("Workflow input serialize error: {}", e)))?;
+        ::kit::workflow::start_named(&__name, &__input).await
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::TestDatabase;
+    use sea_orm_migration::prelude::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static ALWAYS_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static FLAKY_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static CACHE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[workflow_step]
+    async fn always_step() -> Result<i32, FrameworkError> {
+        ALWAYS_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(1)
+    }
+
+    #[workflow_step]
+    async fn flaky_step() -> Result<i32, FrameworkError> {
+        let attempt = FLAKY_CALLS.fetch_add(1, Ordering::SeqCst);
+        if attempt == 0 {
+            Err(FrameworkError::internal("flaky"))
+        } else {
+            Ok(2)
+        }
+    }
+
+    #[workflow]
+    async fn test_workflow() -> Result<i32, FrameworkError> {
+        let a = always_step().await?;
+        let b = flaky_step().await?;
+        Ok(a + b)
+    }
+
+    #[workflow]
+    async fn name_norm_workflow(value: i32) -> Result<i32, FrameworkError> {
+        Ok(value)
+    }
+
+    #[tokio::test]
+    async fn test_step_caching() {
+        let _db = setup_db().await;
+        CACHE_CALLS.store(0, Ordering::SeqCst);
+
+        let handle = store::insert_workflow("cache", "{}", 3)
+            .await
+            .expect("workflow insert");
+
+        let ctx = WorkflowContext::new(handle.id(), Duration::from_secs(30));
+        let _ = ctx
+            .enter(async {
+                ctx.run_step_with_input("cache-step", serde_json::to_string(&()).unwrap(), || async {
+                    CACHE_CALLS.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, FrameworkError>(42)
+                })
+                .await
+                .unwrap()
+            })
+            .await;
+
+        let ctx2 = WorkflowContext::new(handle.id(), Duration::from_secs(30));
+        let value = ctx2
+            .enter(async {
+                ctx2.run_step_with_input("cache-step", serde_json::to_string(&()).unwrap(), || async {
+                    CACHE_CALLS.fetch_add(1, Ordering::SeqCst);
+                    Ok::<_, FrameworkError>(99)
+                })
+                .await
+                .unwrap()
+            })
+            .await;
+
+        assert_eq!(value, 42);
+        assert_eq!(CACHE_CALLS.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_retry_flow() {
+        let _db = setup_db().await;
+        ALWAYS_CALLS.store(0, Ordering::SeqCst);
+        FLAKY_CALLS.store(0, Ordering::SeqCst);
+
+        let input = serde_json::to_string(&()).unwrap();
+        let handle = start_named(
+            &format!("{}::{}", module_path!(), "test_workflow"),
+            &input,
+        )
+        .await
+        .expect("start workflow");
+
+        let claimed = store::mark_running(handle.id(), "test-worker", Duration::from_secs(30))
+            .await
+            .expect("mark running");
+
+        let config = WorkflowConfig::from_env();
+        process_claimed_workflow(claimed, Arc::new(config), "test-worker")
+            .await
+            .expect("process workflow");
+
+        let status = store::get_workflow_status(handle.id()).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Pending);
+
+        let claimed = store::mark_running(handle.id(), "test-worker", Duration::from_secs(30))
+            .await
+            .expect("mark running again");
+
+        let config = WorkflowConfig::from_env();
+        process_claimed_workflow(claimed, Arc::new(config), "test-worker")
+            .await
+            .expect("process workflow again");
+
+        let status = store::get_workflow_status(handle.id()).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Succeeded);
+        assert_eq!(ALWAYS_CALLS.load(Ordering::SeqCst), 1);
+        assert_eq!(FLAKY_CALLS.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_name_normalization() {
+        let _db = setup_db().await;
+
+        let handle = start_workflow!(name_norm_workflow, 5)
+            .await
+            .expect("start workflow macro");
+
+        let record = store::get_workflow_record(handle.id()).await.unwrap();
+        let expected = format!("{}::{}", module_path!(), "name_norm_workflow");
+        assert_eq!(record.name, expected);
+    }
+
+    async fn setup_db() -> TestDatabase {
+        TestDatabase::fresh::<TestMigrator>()
+            .await
+            .expect("test db")
+    }
+
+    pub struct TestMigrator;
+
+    #[async_trait::async_trait]
+    impl MigratorTrait for TestMigrator {
+        fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+            vec![
+                Box::new(CreateWorkflowsTable),
+                Box::new(CreateWorkflowStepsTable),
+            ]
+        }
+    }
+
+    pub struct CreateWorkflowsTable;
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for CreateWorkflowsTable {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .create_table(
+                    Table::create()
+                        .table(Workflows::Table)
+                        .if_not_exists()
+                        .col(
+                            ColumnDef::new(Workflows::Id)
+                                .big_integer()
+                                .not_null()
+                                .auto_increment()
+                                .primary_key(),
+                        )
+                        .col(ColumnDef::new(Workflows::Name).string().not_null())
+                        .col(ColumnDef::new(Workflows::Status).string().not_null())
+                        .col(ColumnDef::new(Workflows::Input).text().not_null())
+                        .col(ColumnDef::new(Workflows::Output).text().null())
+                        .col(ColumnDef::new(Workflows::Error).text().null())
+                        .col(ColumnDef::new(Workflows::Attempts).integer().not_null())
+                        .col(ColumnDef::new(Workflows::MaxAttempts).integer().not_null())
+                        .col(ColumnDef::new(Workflows::NextRunAt).timestamp().null())
+                        .col(ColumnDef::new(Workflows::LockedUntil).timestamp().null())
+                        .col(ColumnDef::new(Workflows::WorkerId).string().null())
+                        .col(
+                            ColumnDef::new(Workflows::CreatedAt)
+                                .timestamp()
+                                .not_null()
+                                .default(Expr::current_timestamp()),
+                        )
+                        .col(
+                            ColumnDef::new(Workflows::UpdatedAt)
+                                .timestamp()
+                                .not_null()
+                                .default(Expr::current_timestamp()),
+                        )
+                        .col(ColumnDef::new(Workflows::StartedAt).timestamp().null())
+                        .col(ColumnDef::new(Workflows::CompletedAt).timestamp().null())
+                        .to_owned(),
+                )
+                .await?;
+
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_workflows_status")
+                        .table(Workflows::Table)
+                        .col(Workflows::Status)
+                        .to_owned(),
+                )
+                .await?;
+
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_workflows_next_run_at")
+                        .table(Workflows::Table)
+                        .col(Workflows::NextRunAt)
+                        .to_owned(),
+                )
+                .await?;
+
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_workflows_locked_until")
+                        .table(Workflows::Table)
+                        .col(Workflows::LockedUntil)
+                        .to_owned(),
+                )
+                .await
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .drop_table(Table::drop().table(Workflows::Table).to_owned())
+                .await
+        }
+    }
+
+    pub struct CreateWorkflowStepsTable;
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for CreateWorkflowStepsTable {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .create_table(
+                    Table::create()
+                        .table(WorkflowSteps::Table)
+                        .if_not_exists()
+                        .col(
+                            ColumnDef::new(WorkflowSteps::Id)
+                                .big_integer()
+                                .not_null()
+                                .auto_increment()
+                                .primary_key(),
+                        )
+                        .col(
+                            ColumnDef::new(WorkflowSteps::WorkflowId)
+                                .big_integer()
+                                .not_null(),
+                        )
+                        .col(ColumnDef::new(WorkflowSteps::StepIndex).integer().not_null())
+                        .col(ColumnDef::new(WorkflowSteps::StepName).string().not_null())
+                        .col(ColumnDef::new(WorkflowSteps::Status).string().not_null())
+                        .col(ColumnDef::new(WorkflowSteps::Input).text().not_null())
+                        .col(ColumnDef::new(WorkflowSteps::Output).text().null())
+                        .col(ColumnDef::new(WorkflowSteps::Error).text().null())
+                        .col(ColumnDef::new(WorkflowSteps::Attempts).integer().not_null())
+                        .col(
+                            ColumnDef::new(WorkflowSteps::CreatedAt)
+                                .timestamp()
+                                .not_null()
+                                .default(Expr::current_timestamp()),
+                        )
+                        .col(
+                            ColumnDef::new(WorkflowSteps::UpdatedAt)
+                                .timestamp()
+                                .not_null()
+                                .default(Expr::current_timestamp()),
+                        )
+                        .col(ColumnDef::new(WorkflowSteps::StartedAt).timestamp().null())
+                        .col(ColumnDef::new(WorkflowSteps::CompletedAt).timestamp().null())
+                        .to_owned(),
+                )
+                .await?;
+
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_workflow_steps_workflow_id")
+                        .table(WorkflowSteps::Table)
+                        .col(WorkflowSteps::WorkflowId)
+                        .to_owned(),
+                )
+                .await?;
+
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_workflow_steps_unique")
+                        .table(WorkflowSteps::Table)
+                        .col(WorkflowSteps::WorkflowId)
+                        .col(WorkflowSteps::StepIndex)
+                        .unique()
+                        .to_owned(),
+                )
+                .await
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .drop_table(Table::drop().table(WorkflowSteps::Table).to_owned())
+                .await
+        }
+    }
+
+    #[derive(DeriveIden)]
+    enum Workflows {
+        Table,
+        Id,
+        Name,
+        Status,
+        Input,
+        Output,
+        Error,
+        Attempts,
+        MaxAttempts,
+        NextRunAt,
+        LockedUntil,
+        WorkerId,
+        CreatedAt,
+        UpdatedAt,
+        StartedAt,
+        CompletedAt,
+    }
+
+    #[derive(DeriveIden)]
+    enum WorkflowSteps {
+        Table,
+        Id,
+        WorkflowId,
+        StepIndex,
+        StepName,
+        Status,
+        Input,
+        Output,
+        Error,
+        Attempts,
+        CreatedAt,
+        UpdatedAt,
+        StartedAt,
+        CompletedAt,
+    }
+}

--- a/framework/src/workflow/registry.rs
+++ b/framework/src/workflow/registry.rs
@@ -1,0 +1,23 @@
+//! Workflow registry via inventory
+
+use crate::error::FrameworkError;
+use std::future::Future;
+use std::pin::Pin;
+
+/// Boxed workflow runner
+pub type WorkflowRunner = fn(&str) -> Pin<Box<dyn Future<Output = Result<String, FrameworkError>> + Send>>;
+
+/// Inventory entry for a workflow
+pub struct WorkflowEntry {
+    pub name: &'static str,
+    pub run: WorkflowRunner,
+}
+
+inventory::collect!(WorkflowEntry);
+
+/// Find a workflow entry by name
+pub fn find(name: &str) -> Option<&'static WorkflowEntry> {
+    inventory::iter::<WorkflowEntry>
+        .into_iter()
+        .find(|entry| entry.name == name)
+}

--- a/framework/src/workflow/store.rs
+++ b/framework/src/workflow/store.rs
@@ -297,6 +297,22 @@ pub async fn mark_failed(id: i64, error: &str) -> Result<(), FrameworkError> {
 pub async fn load_step(
     workflow_id: i64,
     step_index: i32,
+    step_name: &str,
+) -> Result<Option<workflow_steps::Model>, FrameworkError> {
+    let db = DB::connection()?;
+    workflow_steps::Entity::find()
+        .filter(workflow_steps::Column::WorkflowId.eq(workflow_id))
+        .filter(workflow_steps::Column::StepIndex.eq(step_index))
+        .filter(workflow_steps::Column::StepName.eq(step_name))
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))
+}
+
+/// Load any step by workflow + index (used to detect mismatches)
+pub async fn load_step_by_index(
+    workflow_id: i64,
+    step_index: i32,
 ) -> Result<Option<workflow_steps::Model>, FrameworkError> {
     let db = DB::connection()?;
     workflow_steps::Entity::find()

--- a/framework/src/workflow/store.rs
+++ b/framework/src/workflow/store.rs
@@ -1,0 +1,417 @@
+//! Workflow persistence helpers
+
+use crate::database::DB;
+use crate::error::FrameworkError;
+use crate::workflow::config::WorkflowConfig;
+use crate::workflow::entities::{workflow_steps, workflows};
+use crate::workflow::types::{ClaimedWorkflow, StepStatus, WorkflowHandle, WorkflowStatus};
+use chrono::{Duration as ChronoDuration, Utc};
+use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseBackend, EntityTrait, QueryFilter, Set};
+use sea_orm::{ConnectionTrait, Statement};
+use std::time::Duration;
+
+/// Insert a new workflow row (pending)
+pub async fn insert_workflow(
+    name: &str,
+    input: &str,
+    max_attempts: i32,
+) -> Result<WorkflowHandle, FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let model = workflows::ActiveModel {
+        name: Set(name.to_string()),
+        status: Set(WorkflowStatus::Pending.as_str().to_string()),
+        input: Set(input.to_string()),
+        output: Set(None),
+        error: Set(None),
+        attempts: Set(0),
+        max_attempts: Set(max_attempts),
+        next_run_at: Set(None),
+        locked_until: Set(None),
+        worker_id: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+        started_at: Set(None),
+        completed_at: Set(None),
+        ..Default::default()
+    };
+
+    let inserted = model
+        .insert(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(WorkflowHandle::new(inserted.id))
+}
+
+/// Get workflow status
+pub async fn get_workflow_status(id: i64) -> Result<WorkflowStatus, FrameworkError> {
+    let db = DB::connection()?;
+    let model = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?;
+
+    WorkflowStatus::from_str(&model.status)
+        .ok_or_else(|| FrameworkError::internal("Invalid workflow status"))
+}
+
+/// Get workflow output JSON
+pub async fn get_workflow_output(id: i64) -> Result<Option<String>, FrameworkError> {
+    let db = DB::connection()?;
+    let model = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?;
+    Ok(model.output)
+}
+
+/// Load workflow record by id
+pub async fn get_workflow_record(id: i64) -> Result<workflows::Model, FrameworkError> {
+    let db = DB::connection()?;
+    workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))
+}
+
+/// Mark workflow as running (used for tests or manual claim)
+pub async fn mark_running(
+    id: i64,
+    worker_id: &str,
+    lock_timeout: Duration,
+) -> Result<ClaimedWorkflow, FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+    let lock_until = now + ChronoDuration::seconds(lock_timeout.as_secs() as i64);
+
+    let model = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?;
+
+    let attempts = model.attempts + 1;
+    let started_at = model.started_at.unwrap_or(now);
+    let mut active: workflows::ActiveModel = model.into();
+    active.attempts = Set(attempts);
+    active.status = Set(WorkflowStatus::Running.as_str().to_string());
+    active.locked_until = Set(Some(lock_until));
+    active.worker_id = Set(Some(worker_id.to_string()));
+    active.started_at = Set(Some(started_at));
+    active.updated_at = Set(now);
+
+    let updated = active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(ClaimedWorkflow {
+        id: updated.id,
+        name: updated.name,
+        input: updated.input,
+        attempts: updated.attempts,
+        max_attempts: updated.max_attempts,
+    })
+}
+
+/// Claim the next workflow to run (Postgres only)
+pub async fn claim_next_workflow(
+    worker_id: &str,
+    config: &WorkflowConfig,
+) -> Result<Option<ClaimedWorkflow>, FrameworkError> {
+    let db = DB::connection()?;
+    let backend = db.inner().get_database_backend();
+    if backend != DatabaseBackend::Postgres {
+        return Err(FrameworkError::internal(
+            "Workflow worker requires a Postgres database",
+        ));
+    }
+
+    let lock_until = Utc::now().naive_utc()
+        + ChronoDuration::seconds(config.lock_timeout_secs as i64);
+
+    let sql = r#"
+        UPDATE workflows
+        SET status = 'running',
+            attempts = attempts + 1,
+            locked_until = $1,
+            worker_id = $2,
+            started_at = COALESCE(started_at, NOW()),
+            updated_at = NOW()
+        WHERE id = (
+            SELECT id
+            FROM workflows
+            WHERE status = 'pending'
+              AND (next_run_at IS NULL OR next_run_at <= NOW())
+              AND (locked_until IS NULL OR locked_until <= NOW())
+            ORDER BY id
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+        )
+        RETURNING id, name, input, attempts, max_attempts
+    "#;
+
+    let stmt = Statement::from_sql_and_values(
+        DatabaseBackend::Postgres,
+        sql,
+        vec![lock_until.into(), worker_id.into()],
+    );
+
+    let row = db
+        .inner()
+        .query_one(stmt)
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    if let Some(row) = row {
+        let id: i64 = row.try_get("", "id").map_err(|e| FrameworkError::database(e.to_string()))?;
+        let name: String = row.try_get("", "name").map_err(|e| FrameworkError::database(e.to_string()))?;
+        let input: String = row.try_get("", "input").map_err(|e| FrameworkError::database(e.to_string()))?;
+        let attempts: i32 = row.try_get("", "attempts").map_err(|e| FrameworkError::database(e.to_string()))?;
+        let max_attempts: i32 = row.try_get("", "max_attempts").map_err(|e| FrameworkError::database(e.to_string()))?;
+
+        Ok(Some(ClaimedWorkflow {
+            id,
+            name,
+            input,
+            attempts,
+            max_attempts,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Refresh workflow lock lease
+pub async fn refresh_lock(id: i64, lock_timeout: Duration) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+    let lock_until = now + ChronoDuration::seconds(lock_timeout.as_secs() as i64);
+
+    let mut active: workflows::ActiveModel = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?
+        .into();
+
+    active.locked_until = Set(Some(lock_until));
+    active.updated_at = Set(now);
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Mark workflow as succeeded
+pub async fn mark_succeeded(id: i64, output: &str) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let mut active: workflows::ActiveModel = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?
+        .into();
+
+    active.status = Set(WorkflowStatus::Succeeded.as_str().to_string());
+    active.output = Set(Some(output.to_string()));
+    active.error = Set(None);
+    active.completed_at = Set(Some(now));
+    active.locked_until = Set(None);
+    active.worker_id = Set(None);
+    active.updated_at = Set(now);
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Requeue workflow for retry
+pub async fn requeue(id: i64, error: &str, next_run_at: chrono::NaiveDateTime) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let mut active: workflows::ActiveModel = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?
+        .into();
+
+    active.status = Set(WorkflowStatus::Pending.as_str().to_string());
+    active.error = Set(Some(error.to_string()));
+    active.next_run_at = Set(Some(next_run_at));
+    active.locked_until = Set(None);
+    active.worker_id = Set(None);
+    active.updated_at = Set(now);
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Mark workflow as failed
+pub async fn mark_failed(id: i64, error: &str) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let mut active: workflows::ActiveModel = workflows::Entity::find_by_id(id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Workflow not found"))?
+        .into();
+
+    active.status = Set(WorkflowStatus::Failed.as_str().to_string());
+    active.error = Set(Some(error.to_string()));
+    active.completed_at = Set(Some(now));
+    active.locked_until = Set(None);
+    active.worker_id = Set(None);
+    active.updated_at = Set(now);
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Load a step by workflow + index
+pub async fn load_step(
+    workflow_id: i64,
+    step_index: i32,
+) -> Result<Option<workflow_steps::Model>, FrameworkError> {
+    let db = DB::connection()?;
+    workflow_steps::Entity::find()
+        .filter(workflow_steps::Column::WorkflowId.eq(workflow_id))
+        .filter(workflow_steps::Column::StepIndex.eq(step_index))
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))
+}
+
+/// Insert a running step
+pub async fn insert_step_running(
+    workflow_id: i64,
+    step_index: i32,
+    step_name: &str,
+    input: &str,
+) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let model = workflow_steps::ActiveModel {
+        workflow_id: Set(workflow_id),
+        step_index: Set(step_index),
+        step_name: Set(step_name.to_string()),
+        status: Set(StepStatus::Running.as_str().to_string()),
+        input: Set(input.to_string()),
+        output: Set(None),
+        error: Set(None),
+        attempts: Set(1),
+        created_at: Set(now),
+        updated_at: Set(now),
+        started_at: Set(Some(now)),
+        completed_at: Set(None),
+        ..Default::default()
+    };
+
+    model
+        .insert(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Update a step to running and increment attempts
+pub async fn update_step_running(
+    step: workflow_steps::Model,
+    input: &str,
+) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let attempts = step.attempts + 1;
+    let mut active: workflow_steps::ActiveModel = step.into();
+    active.status = Set(StepStatus::Running.as_str().to_string());
+    active.input = Set(input.to_string());
+    active.attempts = Set(attempts);
+    active.updated_at = Set(now);
+    active.started_at = Set(Some(now));
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Mark step succeeded
+pub async fn mark_step_succeeded(step_id: i64, output: &str) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let mut active: workflow_steps::ActiveModel = workflow_steps::Entity::find_by_id(step_id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Step not found"))?
+        .into();
+
+    active.status = Set(StepStatus::Succeeded.as_str().to_string());
+    active.output = Set(Some(output.to_string()));
+    active.error = Set(None);
+    active.updated_at = Set(now);
+    active.completed_at = Set(Some(now));
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}
+
+/// Mark step failed
+pub async fn mark_step_failed(step_id: i64, error: &str) -> Result<(), FrameworkError> {
+    let db = DB::connection()?;
+    let now = Utc::now().naive_utc();
+
+    let mut active: workflow_steps::ActiveModel = workflow_steps::Entity::find_by_id(step_id)
+        .one(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?
+        .ok_or_else(|| FrameworkError::internal("Step not found"))?
+        .into();
+
+    active.status = Set(StepStatus::Failed.as_str().to_string());
+    active.error = Set(Some(error.to_string()));
+    active.updated_at = Set(now);
+    active.completed_at = Set(Some(now));
+
+    active
+        .update(db.inner())
+        .await
+        .map_err(|e| FrameworkError::database(e.to_string()))?;
+
+    Ok(())
+}

--- a/framework/src/workflow/types.rs
+++ b/framework/src/workflow/types.rs
@@ -1,0 +1,128 @@
+//! Workflow public types
+
+use crate::error::FrameworkError;
+use crate::workflow::store;
+use crate::workflow::WorkflowConfig;
+use serde::de::DeserializeOwned;
+use std::time::Duration;
+
+/// Workflow execution status
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowStatus {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+}
+
+impl WorkflowStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(Self::Pending),
+            "running" => Some(Self::Running),
+            "succeeded" => Some(Self::Succeeded),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// Step execution status
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepStatus {
+    Running,
+    Succeeded,
+    Failed,
+}
+
+impl StepStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "running" => Some(Self::Running),
+            "succeeded" => Some(Self::Succeeded),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// Handle for a workflow instance
+#[derive(Debug, Clone)]
+pub struct WorkflowHandle {
+    id: i64,
+}
+
+impl WorkflowHandle {
+    pub(crate) fn new(id: i64) -> Self {
+        Self { id }
+    }
+
+    /// Workflow id
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+
+    /// Fetch the current status
+    pub async fn status(&self) -> Result<WorkflowStatus, FrameworkError> {
+        store::get_workflow_status(self.id).await
+    }
+
+    /// Wait until the workflow finishes (succeeded/failed)
+    pub async fn wait(&self) -> Result<WorkflowStatus, FrameworkError> {
+        let config = WorkflowConfig::default();
+        let poll = Duration::from_millis(config.poll_interval_ms);
+
+        loop {
+            let status = self.status().await?;
+            match status {
+                WorkflowStatus::Succeeded | WorkflowStatus::Failed => return Ok(status),
+                _ => tokio::time::sleep(poll).await,
+            }
+        }
+    }
+
+    /// Get the raw output JSON (if any)
+    pub async fn output_raw(&self) -> Result<Option<String>, FrameworkError> {
+        store::get_workflow_output(self.id).await
+    }
+
+    /// Deserialize output JSON into a type
+    pub async fn output<T: DeserializeOwned>(&self) -> Result<Option<T>, FrameworkError> {
+        match self.output_raw().await? {
+            Some(json) => {
+                let value = serde_json::from_str(&json).map_err(|e| {
+                    FrameworkError::internal(format!("Workflow output deserialize error: {}", e))
+                })?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+/// Workflow record used by the worker
+#[derive(Debug, Clone)]
+pub struct ClaimedWorkflow {
+    pub id: i64,
+    pub name: String,
+    pub input: String,
+    pub attempts: i32,
+    pub max_attempts: i32,
+}

--- a/kit-cli/src/commands/mod.rs
+++ b/kit-cli/src/commands/mod.rs
@@ -20,3 +20,5 @@ pub mod schedule_run;
 pub mod schedule_work;
 pub mod serve;
 pub mod web_run;
+pub mod workflow_install;
+pub mod workflow_work;

--- a/kit-cli/src/commands/workflow_install.rs
+++ b/kit-cli/src/commands/workflow_install.rs
@@ -1,0 +1,182 @@
+//! workflow:install command - Install workflow migrations
+
+use console::style;
+use std::fs;
+use std::path::Path;
+
+use crate::templates;
+
+const WORKFLOWS_MIGRATION: &str = "m20240101_000003_create_workflows_table";
+const WORKFLOW_STEPS_MIGRATION: &str = "m20240101_000004_create_workflow_steps_table";
+
+pub fn run() {
+    let migrations_dir = Path::new("src/migrations");
+    let mod_file = migrations_dir.join("mod.rs");
+
+    if !Path::new("src").exists() {
+        eprintln!(
+            "{} Not in a Kit project root directory",
+            style("Error:").red().bold()
+        );
+        std::process::exit(1);
+    }
+
+    if !migrations_dir.exists() {
+        if let Err(e) = fs::create_dir_all(migrations_dir) {
+            eprintln!(
+                "{} Failed to create migrations directory: {}",
+                style("Error:").red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+        println!("{} Created src/migrations/", style("✓").green());
+    }
+
+    let workflows_file = migrations_dir.join(format!("{}.rs", WORKFLOWS_MIGRATION));
+    let steps_file = migrations_dir.join(format!("{}.rs", WORKFLOW_STEPS_MIGRATION));
+
+    if !workflows_file.exists() {
+        if let Err(e) = fs::write(&workflows_file, templates::create_workflows_migration()) {
+            eprintln!(
+                "{} Failed to write workflows migration: {}",
+                style("Error:").red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+        println!("{} Created {}", style("✓").green(), workflows_file.display());
+    } else {
+        println!("{} {} already exists", style("Info:").yellow().bold(), workflows_file.display());
+    }
+
+    if !steps_file.exists() {
+        if let Err(e) = fs::write(&steps_file, templates::create_workflow_steps_migration()) {
+            eprintln!(
+                "{} Failed to write workflow steps migration: {}",
+                style("Error:").red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+        println!("{} Created {}", style("✓").green(), steps_file.display());
+    } else {
+        println!("{} {} already exists", style("Info:").yellow().bold(), steps_file.display());
+    }
+
+    if mod_file.exists() {
+        if let Err(e) = update_mod_file(&mod_file, WORKFLOWS_MIGRATION) {
+            eprintln!(
+                "{} Failed to update mod.rs: {}",
+                style("Error:").red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+        if let Err(e) = update_mod_file(&mod_file, WORKFLOW_STEPS_MIGRATION) {
+            eprintln!(
+                "{} Failed to update mod.rs: {}",
+                style("Error:").red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+        println!("{} Updated src/migrations/mod.rs", style("✓").green());
+    } else {
+        let mod_content = format!(
+            "pub use sea_orm_migration::prelude::*;\n\nmod {};\nmod {};\n\n\
+            pub struct Migrator;\n\n\
+            #[async_trait::async_trait]\n\
+            impl MigratorTrait for Migrator {{\n\
+                fn migrations() -> Vec<Box<dyn MigrationTrait>> {{\n\
+                    vec![\n\
+                        Box::new({}::Migration),\n\
+                        Box::new({}::Migration),\n\
+                    ]\n\
+                }}\n\
+            }}\n",
+            WORKFLOWS_MIGRATION,
+            WORKFLOW_STEPS_MIGRATION,
+            WORKFLOWS_MIGRATION,
+            WORKFLOW_STEPS_MIGRATION
+        );
+
+        if let Err(e) = fs::write(&mod_file, mod_content) {
+            eprintln!(
+                "{} Failed to create mod.rs: {}",
+                style("Error:").red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+        println!("{} Created src/migrations/mod.rs", style("✓").green());
+    }
+
+    println!();
+    println!("Workflow migrations installed.");
+    println!("Run `kit migrate` to apply them.");
+}
+
+fn update_mod_file(mod_file: &Path, module_name: &str) -> Result<(), String> {
+    let content = fs::read_to_string(mod_file).map_err(|e| format!("Failed to read mod.rs: {}", e))?;
+
+    let mod_decl = format!("mod {};", module_name);
+    let entry_line = format!("            Box::new({}::Migration),", module_name);
+
+    let lines: Vec<&str> = content.lines().collect();
+
+    let has_mod = content.contains(&mod_decl);
+    let has_entry = content.contains(&entry_line);
+
+    let mut last_mod_idx = None;
+    let mut last_entry_idx = None;
+    let mut vec_idx = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("mod ") || trimmed.starts_with("pub mod ") {
+            last_mod_idx = Some(i);
+        }
+        if trimmed.contains("Box::new(") {
+            last_entry_idx = Some(i);
+        }
+        if trimmed.contains("vec![") {
+            vec_idx = Some(i);
+        }
+    }
+
+    let mut new_lines = Vec::new();
+
+    for (i, line) in lines.iter().enumerate() {
+        new_lines.push(line.to_string());
+
+        if !has_mod {
+            if let Some(idx) = last_mod_idx {
+                if i == idx {
+                    new_lines.push(mod_decl.clone());
+                }
+            }
+        }
+
+        if !has_entry {
+            if let Some(idx) = last_entry_idx {
+                if i == idx {
+                    new_lines.push(entry_line.clone());
+                }
+            } else if let Some(idx) = vec_idx {
+                if i == idx {
+                    new_lines.push(entry_line.clone());
+                }
+            }
+        }
+    }
+
+    if !has_mod && last_mod_idx.is_none() {
+        new_lines.insert(1, mod_decl.clone());
+    }
+
+    let new_content = new_lines.join("\n") + "\n";
+    fs::write(mod_file, new_content).map_err(|e| format!("Failed to write mod.rs: {}", e))?;
+
+    Ok(())
+}

--- a/kit-cli/src/commands/workflow_work.rs
+++ b/kit-cli/src/commands/workflow_work.rs
@@ -1,0 +1,32 @@
+//! workflow:work command - Run the workflow worker daemon
+
+use console::style;
+use std::process::Command;
+
+pub fn run() {
+    println!("{} Starting workflow worker...", style("->").cyan());
+    println!("{}", style("Press Ctrl+C to stop").dim());
+    println!();
+
+    let status = Command::new("cargo")
+        .args(["run", "--quiet", "--", "workflow:work"])
+        .status()
+        .expect("Failed to execute cargo command");
+
+    if !status.success() {
+        if let Some(code) = status.code() {
+            if code != 130 {
+                eprintln!();
+                eprintln!(
+                    "{} Workflow worker exited with error (code: {})",
+                    style("Error:").red().bold(),
+                    code
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    println!();
+    println!("{} Workflow worker stopped.", style("->").cyan());
+}

--- a/kit-cli/src/main.rs
+++ b/kit-cli/src/main.rs
@@ -150,6 +150,12 @@ enum Commands {
     /// List all registered scheduled tasks
     #[command(name = "schedule:list")]
     ScheduleList,
+    /// Start the workflow worker daemon
+    #[command(name = "workflow:work")]
+    WorkflowWork,
+    /// Install workflow migrations
+    #[command(name = "workflow:install")]
+    WorkflowInstall,
 }
 
 fn main() {
@@ -234,6 +240,12 @@ fn main() {
         }
         Commands::ScheduleList => {
             commands::schedule_list::run();
+        }
+        Commands::WorkflowWork => {
+            commands::workflow_work::run();
+        }
+        Commands::WorkflowInstall => {
+            commands::workflow_install::run();
         }
     }
 }

--- a/kit-cli/src/templates/files/backend/migrations/create_workflow_steps_table.rs.tpl
+++ b/kit-cli/src/templates/files/backend/migrations/create_workflow_steps_table.rs.tpl
@@ -1,0 +1,93 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(WorkflowSteps::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(WorkflowSteps::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(WorkflowSteps::WorkflowId).big_integer().not_null())
+                    .col(ColumnDef::new(WorkflowSteps::StepIndex).integer().not_null())
+                    .col(ColumnDef::new(WorkflowSteps::StepName).string().not_null())
+                    .col(ColumnDef::new(WorkflowSteps::Status).string().not_null())
+                    .col(ColumnDef::new(WorkflowSteps::Input).text().not_null())
+                    .col(ColumnDef::new(WorkflowSteps::Output).text().null())
+                    .col(ColumnDef::new(WorkflowSteps::Error).text().null())
+                    .col(ColumnDef::new(WorkflowSteps::Attempts).integer().not_null())
+                    .col(
+                        ColumnDef::new(WorkflowSteps::CreatedAt)
+                            .timestamp()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(WorkflowSteps::UpdatedAt)
+                            .timestamp()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(ColumnDef::new(WorkflowSteps::StartedAt).timestamp().null())
+                    .col(ColumnDef::new(WorkflowSteps::CompletedAt).timestamp().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_workflow_steps_workflow_id")
+                    .table(WorkflowSteps::Table)
+                    .col(WorkflowSteps::WorkflowId)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_workflow_steps_unique")
+                    .table(WorkflowSteps::Table)
+                    .col(WorkflowSteps::WorkflowId)
+                    .col(WorkflowSteps::StepIndex)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(WorkflowSteps::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum WorkflowSteps {
+    Table,
+    Id,
+    WorkflowId,
+    StepIndex,
+    StepName,
+    Status,
+    Input,
+    Output,
+    Error,
+    Attempts,
+    CreatedAt,
+    UpdatedAt,
+    StartedAt,
+    CompletedAt,
+}

--- a/kit-cli/src/templates/files/backend/migrations/create_workflows_table.rs.tpl
+++ b/kit-cli/src/templates/files/backend/migrations/create_workflows_table.rs.tpl
@@ -1,0 +1,105 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Workflows::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Workflows::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Workflows::Name).string().not_null())
+                    .col(ColumnDef::new(Workflows::Status).string().not_null())
+                    .col(ColumnDef::new(Workflows::Input).text().not_null())
+                    .col(ColumnDef::new(Workflows::Output).text().null())
+                    .col(ColumnDef::new(Workflows::Error).text().null())
+                    .col(ColumnDef::new(Workflows::Attempts).integer().not_null())
+                    .col(ColumnDef::new(Workflows::MaxAttempts).integer().not_null())
+                    .col(ColumnDef::new(Workflows::NextRunAt).timestamp().null())
+                    .col(ColumnDef::new(Workflows::LockedUntil).timestamp().null())
+                    .col(ColumnDef::new(Workflows::WorkerId).string().null())
+                    .col(
+                        ColumnDef::new(Workflows::CreatedAt)
+                            .timestamp()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(
+                        ColumnDef::new(Workflows::UpdatedAt)
+                            .timestamp()
+                            .not_null()
+                            .default(Expr::current_timestamp()),
+                    )
+                    .col(ColumnDef::new(Workflows::StartedAt).timestamp().null())
+                    .col(ColumnDef::new(Workflows::CompletedAt).timestamp().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_workflows_status")
+                    .table(Workflows::Table)
+                    .col(Workflows::Status)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_workflows_next_run_at")
+                    .table(Workflows::Table)
+                    .col(Workflows::NextRunAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_workflows_locked_until")
+                    .table(Workflows::Table)
+                    .col(Workflows::LockedUntil)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Workflows::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Workflows {
+    Table,
+    Id,
+    Name,
+    Status,
+    Input,
+    Output,
+    Error,
+    Attempts,
+    MaxAttempts,
+    NextRunAt,
+    LockedUntil,
+    WorkerId,
+    CreatedAt,
+    UpdatedAt,
+    StartedAt,
+    CompletedAt,
+}

--- a/kit-cli/src/templates/mod.rs
+++ b/kit-cli/src/templates/mod.rs
@@ -52,6 +52,14 @@ pub fn home_controller() -> &'static str {
     include_str!("files/backend/controllers/home.rs.tpl")
 }
 
+pub fn create_workflows_migration() -> &'static str {
+    include_str!("files/backend/migrations/create_workflows_table.rs.tpl")
+}
+
+pub fn create_workflow_steps_migration() -> &'static str {
+    include_str!("files/backend/migrations/create_workflow_steps_table.rs.tpl")
+}
+
 // Middleware templates
 
 pub fn middleware_mod() -> &'static str {

--- a/kit-macros/src/lib.rs
+++ b/kit-macros/src/lib.rs
@@ -21,6 +21,8 @@ mod request;
 mod service;
 mod test_macro;
 mod utils;
+mod workflow;
+mod workflow_step;
 
 /// Derive macro for generating `Serialize` implementation for Inertia props
 ///
@@ -334,6 +336,18 @@ pub fn request(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn kit_test(attr: TokenStream, input: TokenStream) -> TokenStream {
     kit_test::kit_test_impl(attr, input)
+}
+
+/// Attribute macro for defining durable workflows
+#[proc_macro_attribute]
+pub fn workflow(attr: TokenStream, input: TokenStream) -> TokenStream {
+    workflow::workflow_impl(attr, input)
+}
+
+/// Attribute macro for defining durable workflow steps
+#[proc_macro_attribute]
+pub fn workflow_step(attr: TokenStream, input: TokenStream) -> TokenStream {
+    workflow_step::workflow_step_impl(attr, input)
 }
 
 /// Group related tests with a descriptive name

--- a/kit-macros/src/workflow.rs
+++ b/kit-macros/src/workflow.rs
@@ -1,0 +1,190 @@
+//! Workflow attribute macro
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, FnArg, ItemFn, Pat, ReturnType, Type};
+
+pub fn workflow_impl(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input_fn = parse_macro_input!(input as ItemFn);
+
+    if input_fn.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(
+            input_fn.sig.fn_token,
+            "#[workflow] requires an async function",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let fn_name = &input_fn.sig.ident;
+    let fn_vis = &input_fn.vis;
+    let fn_attrs = &input_fn.attrs;
+    let fn_output = &input_fn.sig.output;
+    let fn_block = &input_fn.block;
+    let fn_inputs = &input_fn.sig.inputs;
+
+    let mut arg_idents = Vec::new();
+    let mut arg_types = Vec::new();
+
+    for arg in fn_inputs.iter() {
+        match arg {
+            FnArg::Typed(pat_type) => match &*pat_type.pat {
+                Pat::Ident(ident) => {
+                    arg_idents.push(ident.ident.clone());
+                    arg_types.push((*pat_type.ty).clone());
+                }
+                _ => {
+                    return syn::Error::new_spanned(
+                        &pat_type.pat,
+                        "#[workflow] parameters must be simple identifiers",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+            },
+            FnArg::Receiver(_) => {
+                return syn::Error::new_spanned(
+                    arg,
+                    "#[workflow] does not support methods with self",
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
+    }
+
+    let ok_type = match extract_result_ok_type(&input_fn.sig.output) {
+        Ok(t) => t,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    let deser_args = build_deser_args(&arg_idents, &arg_types);
+
+    let runner_name = format_ident!("__kit_workflow_runner_{}", fn_name);
+
+    let expanded = quote! {
+        #(#fn_attrs)*
+        #fn_vis async fn #fn_name(#fn_inputs) #fn_output {
+            #fn_block
+        }
+
+        #[doc(hidden)]
+        fn #runner_name(__input: &str) -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = Result<String, ::kit::FrameworkError>> + Send>> {
+            Box::pin(async move {
+                #deser_args
+                let __result: #ok_type = #fn_name(#(#arg_idents),*).await?;
+                let __json = ::kit::serde_json::to_string(&__result)
+                    .map_err(|e| ::kit::FrameworkError::internal(format!("Workflow output serialize error: {}", e)))?;
+                Ok(__json)
+            })
+        }
+
+        ::kit::inventory::submit! {
+            ::kit::workflow::registry::WorkflowEntry {
+                name: concat!(module_path!(), "::", stringify!(#fn_name)),
+                run: #runner_name,
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn extract_result_ok_type(output: &ReturnType) -> Result<Type, syn::Error> {
+    match output {
+        ReturnType::Type(_, ty) => match &**ty {
+            Type::Path(path) => {
+                let last = path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new_spanned(ty, "Invalid return type for #[workflow]")
+                })?;
+
+                if last.ident != "Result" {
+                    return Err(syn::Error::new_spanned(
+                        ty,
+                        "#[workflow] must return Result<T, FrameworkError>",
+                    ));
+                }
+
+                match &last.arguments {
+                    syn::PathArguments::AngleBracketed(args) => {
+                        let mut iter = args.args.iter();
+                        let ok = iter.next().ok_or_else(|| {
+                            syn::Error::new_spanned(ty, "Result must have ok type")
+                        })?;
+                        let err = iter.next().ok_or_else(|| {
+                            syn::Error::new_spanned(ty, "Result must have error type")
+                        })?;
+
+                        let ok_ty = match ok {
+                            syn::GenericArgument::Type(t) => t.clone(),
+                            _ => {
+                                return Err(syn::Error::new_spanned(
+                                    ok,
+                                    "Invalid ok type",
+                                ))
+                            }
+                        };
+
+                        let err_ty = match err {
+                            syn::GenericArgument::Type(t) => t,
+                            _ => {
+                                return Err(syn::Error::new_spanned(
+                                    err,
+                                    "Invalid error type",
+                                ))
+                            }
+                        };
+
+                        if !is_framework_error(err_ty) {
+                            return Err(syn::Error::new_spanned(
+                                err_ty,
+                                "#[workflow] must return Result<T, FrameworkError>",
+                            ));
+                        }
+
+                        Ok(ok_ty)
+                    }
+                    _ => Err(syn::Error::new_spanned(
+                        ty,
+                        "#[workflow] must return Result<T, FrameworkError>",
+                    )),
+                }
+            }
+            _ => Err(syn::Error::new_spanned(
+                ty,
+                "#[workflow] must return Result<T, FrameworkError>",
+            )),
+        },
+        ReturnType::Default => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "#[workflow] must return Result<T, FrameworkError>",
+        )),
+    }
+}
+
+fn is_framework_error(ty: &Type) -> bool {
+    if let Type::Path(path) = ty {
+        if let Some(last) = path.path.segments.last() {
+            return last.ident == "FrameworkError";
+        }
+    }
+    false
+}
+
+fn build_deser_args(arg_idents: &[syn::Ident], arg_types: &[Type]) -> TokenStream2 {
+    match arg_idents.len() {
+        0 => {
+            quote! {
+                let _: () = ::kit::serde_json::from_str(__input)
+                    .map_err(|e| ::kit::FrameworkError::internal(format!("Workflow input deserialize error: {}", e)))?;
+            }
+        }
+        _ => {
+            quote! {
+                let (#(#arg_idents),*,): (#(#arg_types),*,) = ::kit::serde_json::from_str(__input)
+                    .map_err(|e| ::kit::FrameworkError::internal(format!("Workflow input deserialize error: {}", e)))?;
+            }
+        }
+    }
+}

--- a/kit-macros/src/workflow_step.rs
+++ b/kit-macros/src/workflow_step.rs
@@ -1,0 +1,166 @@
+//! Workflow step attribute macro
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, FnArg, ItemFn, Pat, ReturnType, Type};
+
+pub fn workflow_step_impl(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input_fn = parse_macro_input!(input as ItemFn);
+
+    if input_fn.sig.asyncness.is_none() {
+        return syn::Error::new_spanned(
+            input_fn.sig.fn_token,
+            "#[workflow_step] requires an async function",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let fn_name = &input_fn.sig.ident;
+    let fn_vis = &input_fn.vis;
+    let fn_attrs = &input_fn.attrs;
+    let fn_output = &input_fn.sig.output;
+    let fn_block = &input_fn.block;
+    let fn_inputs = &input_fn.sig.inputs;
+
+    if let Err(err) = ensure_result_framework_error(fn_output) {
+        return err.to_compile_error().into();
+    }
+
+    let mut arg_idents = Vec::new();
+    for arg in fn_inputs.iter() {
+        match arg {
+            FnArg::Typed(pat_type) => match &*pat_type.pat {
+                Pat::Ident(ident) => arg_idents.push(ident.ident.clone()),
+                _ => {
+                    return syn::Error::new_spanned(
+                        &pat_type.pat,
+                        "#[workflow_step] parameters must be simple identifiers",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+            },
+            FnArg::Receiver(_) => {
+                return syn::Error::new_spanned(
+                    arg,
+                    "#[workflow_step] does not support methods with self",
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
+    }
+
+    let inner_name = format_ident!("__kit_workflow_step_inner_{}", fn_name);
+    let input_json = build_input_json(&arg_idents);
+
+    let expanded = quote! {
+        #(#fn_attrs)*
+        #fn_vis async fn #inner_name(#fn_inputs) #fn_output {
+            #fn_block
+        }
+
+        #fn_vis async fn #fn_name(#fn_inputs) #fn_output {
+            if let Some(ctx) = ::kit::workflow::WorkflowContext::current() {
+                let __input_json = #input_json;
+                ctx.run_step_with_input(
+                    stringify!(#fn_name),
+                    __input_json,
+                    || async move { #inner_name(#(#arg_idents),*).await },
+                )
+                .await
+            } else {
+                #inner_name(#(#arg_idents),*).await
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn ensure_result_framework_error(output: &ReturnType) -> Result<(), syn::Error> {
+    match output {
+        ReturnType::Type(_, ty) => match &**ty {
+            Type::Path(path) => {
+                let last = path.path.segments.last().ok_or_else(|| {
+                    syn::Error::new_spanned(ty, "Invalid return type for #[workflow_step]")
+                })?;
+
+                if last.ident != "Result" {
+                    return Err(syn::Error::new_spanned(
+                        ty,
+                        "#[workflow_step] must return Result<T, FrameworkError>",
+                    ));
+                }
+
+                match &last.arguments {
+                    syn::PathArguments::AngleBracketed(args) => {
+                        let mut iter = args.args.iter();
+                        iter.next().ok_or_else(|| {
+                            syn::Error::new_spanned(ty, "Result must have ok type")
+                        })?;
+                        let err = iter.next().ok_or_else(|| {
+                            syn::Error::new_spanned(ty, "Result must have error type")
+                        })?;
+
+                        let err_ty = match err {
+                            syn::GenericArgument::Type(t) => t,
+                            _ => {
+                                return Err(syn::Error::new_spanned(
+                                    err,
+                                    "Invalid error type",
+                                ))
+                            }
+                        };
+
+                        if !is_framework_error(err_ty) {
+                            return Err(syn::Error::new_spanned(
+                                err_ty,
+                                "#[workflow_step] must return Result<T, FrameworkError>",
+                            ));
+                        }
+
+                        Ok(())
+                    }
+                    _ => Err(syn::Error::new_spanned(
+                        ty,
+                        "#[workflow_step] must return Result<T, FrameworkError>",
+                    )),
+                }
+            }
+            _ => Err(syn::Error::new_spanned(
+                ty,
+                "#[workflow_step] must return Result<T, FrameworkError>",
+            )),
+        },
+        ReturnType::Default => Err(syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "#[workflow_step] must return Result<T, FrameworkError>",
+        )),
+    }
+}
+
+fn is_framework_error(ty: &Type) -> bool {
+    if let Type::Path(path) = ty {
+        if let Some(last) = path.path.segments.last() {
+            return last.ident == "FrameworkError";
+        }
+    }
+    false
+}
+
+fn build_input_json(arg_idents: &[syn::Ident]) -> TokenStream2 {
+    if arg_idents.is_empty() {
+        quote! {
+            ::kit::serde_json::to_string(&())
+                .map_err(|e| ::kit::FrameworkError::internal(format!("Workflow step serialize error: {}", e)))?
+        }
+    } else {
+        quote! {
+            ::kit::serde_json::to_string(&(#(&#arg_idents),*,))
+                .map_err(|e| ::kit::FrameworkError::internal(format!("Workflow step serialize error: {}", e)))?
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a Postgres-backed durable workflow engine with step persistence, automatic retries, and a worker daemon. It also adds workflow macros for clean DX, a `start_workflow!` enqueue macro, and CLI commands to run workers and install migrations.

## Problem
Kit lacked a durable background workflow system. There was no built-in way to persist workflow state in Postgres, resume from failed steps, or run a dedicated worker process similar to Laravel’s `queue:work`/scheduled jobs.

## Root Cause
No workflow runtime or storage layer existed in the framework, and the CLI had no generator or worker entrypoint for a durable workflow engine.

## Fix
- Introduced a new `workflow` module with config, registry, storage, context, and worker loop.
- Added `#[workflow]` and `#[workflow_step]` attribute macros plus `start_workflow!`.
- Added `workflow:work` runtime command and `workflow:install` CLI command.
- Added migration templates for `workflows` and `workflow_steps` tables.

## User Impact
Developers can now define durable workflows and steps in Rust, enqueue them programmatically, and run them in production using a dedicated worker process. Failed workflows retry and resume from the last successful step.

## Tests
- `cargo check -p kit-rs`
- `cargo check -p kit-cli`
